### PR TITLE
Fix TypeError with BigInt Args during Unwinding in wrapExportFn

### DIFF
--- a/asyncify.mjs
+++ b/asyncify.mjs
@@ -115,7 +115,7 @@ class Asyncify {
         this.value = await this.value;
         this.assertNoneState();
         this.exports.asyncify_start_rewind(DATA_ADDR);
-        result = fn();
+        result = fn(...args);
       }
 
       this.assertNoneState();


### PR DESCRIPTION
### Problem
When wasm export functions have arguments containing BigInt, the `wrapExportFn` function encounters an issue when calling `fn` while the state is `Unwinding`. This occurs because the `fn` function lacks arguments, leading to the following error:
> Uncaught (in promise) TypeError: can't convert undefined to BigInt

### Solution
This pull request addresses the issue by ensuring that the necessary arguments are passed when calling `fn` during the unwinding state.
